### PR TITLE
chore(deps): update default registry's baseline to `b322364f06308bdd24823f9d8f03fe0cc86fd46f`

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "0affe8710a4a5b26328e909fe1ad7146df39d108",
+    "baseline": "b322364f06308bdd24823f9d8f03fe0cc86fd46f",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
This PR updates default registry's baseline to `b322364f06308bdd24823f9d8f03fe0cc86fd46f`.